### PR TITLE
Fix typo in dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     install_requires=[
         "cbor2",
         "pycose",
-        "rfc9292",
+        "rfc9290",
     ],
 )


### PR DESCRIPTION
Testing statement:

`(base) Jons-MacBook-Pro:py-scrapi jag$ make wheel
pip wheel . -w dist
Processing /Users/jag/repos/py-scrapi
  Preparing metadata (setup.py) ... done
Collecting cbor2 (from py_scrapi==0.1.0)
  Using cached cbor2-5.6.5-cp311-cp311-macosx_11_0_arm64.whl.metadata (6.0 kB)
Collecting pycose (from py_scrapi==0.1.0)
  Using cached pycose-1.1.0-py3-none-any.whl.metadata (6.5 kB)
Collecting rfc9290 (from py_scrapi==0.1.0)
  Using cached rfc9290-0.1.1-py3-none-any.whl.metadata (1.2 kB)

...

Building wheels for collected packages: py_scrapi
  Building wheel for py_scrapi (setup.py) ... done
  Created wheel for py_scrapi: filename=py_scrapi-0.1.0-py3-none-any.whl size=8595 sha256=5f7278676cce865db9853c123a47cec48fe2409da51605d800b10e1b06f63bd4
  Stored in directory: /Users/jag/Library/Caches/pip/wheels/3c/85/c8/f42ab589136bf50929a9f2e7ef1bc4bbeb5ce0b396469d6d92
Successfully built py_scrapi
`